### PR TITLE
remove spillage

### DIFF
--- a/apps/docs/app/libraries/Homepage.tsx
+++ b/apps/docs/app/libraries/Homepage.tsx
@@ -390,7 +390,7 @@ export function Homepage({
           <span className="text-[#00a3a4]">React</span> &{" "}
           <span className="text-[#00d493]">Next.js</span> applications.
         </h3>
-        <div className="mt-[50vh] h-[200svh]">
+        <div className="mt-[50vh]">
           <Sandbox />
         </div>
       </SidebarPage>


### PR DESCRIPTION
### Context
The docs site was having some interesting spillage with the h-200svh because its an approximite size and doesn't leave room for error, added min- to fix