### PR TITLE
Modal - Make it not jump on scroll

### DIFF
--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -76,7 +76,11 @@
 */
 
 html:has(dialog[open]) {
-  overflow: hidden;
+  touch-action: none;
+  -webkit-overflow-scrolling: none;
+  overscroll-behavior: none;
+  position: fixed;
+  overflow-y: scroll;
 }
 
 body {


### PR DESCRIPTION
### Context
instead of overflow hidden, we can make the html body fixed and have overflow-y scroll so that the scrollbar doesn't pop in and out